### PR TITLE
Copy kernel config before building image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,6 +28,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
+	"initializeCommand": "./bin/copy-kernel-config.sh",
 	"postCreateCommand": "./bin/init.sh",
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "idw",

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bundler_example/Gemfile.lock
 docker-image-id.txt
+kernelconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,13 @@ RUN apt-get install -y apt-transport-https ca-certificates curl gnupg-agent soft
 # Get the kernel headers (some BCC tools need them)
 # Note that this is not as simple as getting the headers for the container's 
 # Linux version. They need to be the headers for the Docker host kernel.
+
+# Assumes that the kernel configuration for the host
+# kernel is in a file on the host called
+# `kernelconfig` in the same directory as this
+# Dockerfile.  bin/copy-kernel-config.sh is a good way
+# to get the right config in the right place.
+COPY kernelconfig /root/kernelconfig
 COPY ./bin/install-kernel-headers.sh /root/
 RUN cd /root && sh install-kernel-headers.sh 
 

--- a/bin/copy-kernel-config.sh
+++ b/bin/copy-kernel-config.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Fedora does not make the kernel config of the
+# running kernel available at /proc/config.gz, so it
+# is not accessible when building the image without
+# doing something manually.
+#
+# This copies the kernel config to a file in the
+# current directory in a (hopefully) cross-distro way,
+# and that file is then copied into the image in the
+# Dockerfile.
+#
+# https://blog.fpmurphy.com/2015/10/what-is-procconfig-gz.html
+if [ -f /proc/config.gz ]; then
+  zcat /proc/config.gz > kernelconfig
+elif [ -f /boot/config-$(uname -r) ]; then
+  cp /boot/config-$(uname -r) kernelconfig
+else
+  echo "Could not find kernel configuration!"
+  exit 1
+fi

--- a/bin/install-kernel-headers.sh
+++ b/bin/install-kernel-headers.sh
@@ -3,18 +3,22 @@
 # Get the kernel headers for this linux version
 # Yoinked from https://github.com/iovisor/bpftrace/blob/master/INSTALL.md#kernel-headers-install
 
-set -e
+set -ex
 
 KERNEL_VERSION="${KERNEL_VERSION:-$(uname -r)}"
 kernel_version="$(echo "${KERNEL_VERSION}" | awk -vFS=- '{ print $1 }')"
 major_version="$(echo "${KERNEL_VERSION}" | awk -vFS=. '{ print $1 }')"
 
-apt-get install -y build-essential bc curl flex bison libelf-dev
+apt-get install -y build-essential bc curl flex bison libelf-dev libssl-dev
 
 mkdir -p /usr/src/linux
 curl -sL "https://www.kernel.org/pub/linux/kernel/v${major_version}.x/linux-$kernel_version.tar.gz"     | tar --strip-components=1 -xzf - -C /usr/src/linux
 cd /usr/src/linux
-zcat /proc/config.gz > .config
+
+# Fedora doesn't have kernel config available at
+# /proc/config.gz
+# zcat /proc/config.gz > .config
+cat /root/kernelconfig > .config
 make ARCH=x86 oldconfig
 make ARCH=x86 prepare
 mkdir -p /lib/modules/$(uname -r)


### PR DESCRIPTION
Some linux distros (at least Fedora 32) don't have the configuration of
the running kernel exposed at /proc/config.gz.  If this is the case,
then we somehow have to get the configuration of the host kernel into
the Docker image when building it.

* Add a script to copy the host kernel config into a file at the root of
  the repo in a (hopeully) cross-distro way
* Change the Dockerfile to copy the kernel config from the from this
  file on the host into the image
* Add an `initializeCommand` to the VS Code `.devcontainer` stuff to run
  this script automatically before building the image

There's very likely a better way to do this, but this worked for me on
Fedora 32 to get the Docker image to build automatically from VS Code.